### PR TITLE
feat: Add user API endpoints

### DIFF
--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -10,3 +10,11 @@ from api.v1.views.index import *
 from api.v1.views.states import *
 
 from api.v1.views.cities import *
+
+from api.v1.views.amenities import *
+
+from api.v1.views.users import *
+
+from api.v1.views.places import *
+
+from api.v1.views.places_reviews import *

--- a/api/v1/views/amenities.py
+++ b/api/v1/views/amenities.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+"""Amenity objects that handles all default RestFul API actions"""
+
+from flask import jsonify, abort, request
+from models import storage
+from api.v1.views import app_views
+from models.amenity import Amenity
+
+
+@app_views.route('/amenities', methods=['GET'], strict_slashes=False)
+def get_amenities():
+    """Retrieves the list of all Amenity objects"""
+    amenities_list = []
+    for amenity in storage.all(Amenity).values():
+        amenities_list.append(amenity.to_dict())
+    return jsonify(amenities_list)
+
+
+@app_views.route('/amenities/<string:amenity_id>', methods=['GET'],
+                 strict_slashes=False)
+def get_amenity(amenity_id):
+    """Retrieves a Amenity object"""
+    amenity = storage.get(Amenity, amenity_id)
+    if amenity is None:
+        abort(404)
+    return jsonify(amenity.to_dict())
+
+
+@app_views.route('/amenities/<string:amenity_id>', methods=['DELETE'],
+                 strict_slashes=False)
+def delete_amenity(amenity_id):
+    """Deletes a Amenity object"""
+    amenity = storage.get(Amenity, amenity_id)
+    if amenity is None:
+        abort(404)
+    storage.delete(amenity)
+    storage.save()
+    return {}, 200
+
+
+@app_views.route('/amenities', methods=['POST'], strict_slashes=False)
+def create_amenity():
+    """Creates a Amenity"""
+    amenity_dict = request.get_json()
+    if amenity_dict is None:
+        abort(400, 'Not a JSON')
+    if 'name' not in amenity_dict.keys():
+        abort(400, 'Missing name')
+    new_amenity = Amenity(**amenity_dict)
+    storage.new(new_amenity)
+    storage.save()
+    return jsonify(new_amenity.to_dict()), 201
+
+
+@app_views.route('/amenities/<string:amenity_id>', methods=['PUT'],
+                 strict_slashes=False)
+def update_amenity(amenity_id):
+    """Updates a Amenity object"""
+    amenity = storage.get(Amenity, amenity_id)
+    if amenity is None:
+        abort(404)
+    amenity_dict = request.get_json()
+    if amenity_dict is None:
+        abort(400, 'Not a JSON')
+    for key, value in amenity_dict.items():
+        if key not in ['id', 'created_at', 'updated_at']:
+            setattr(amenity, key, value)
+    storage.save()
+    return jsonify(amenity.to_dict()), 200
+
+
+if __name__ == '__main__':
+    pass

--- a/api/v1/views/places.py
+++ b/api/v1/views/places.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+"""Places objects that handles all default RestFul API actions"""
+
+from flask import jsonify, abort, request
+from models import storage
+from api.v1.views import app_views
+from models.place import Place
+from models.city import City
+from models.user import User
+
+
+@app_views.route('/cities/<string:city_id>/places', methods=['GET'],
+                 strict_slashes=False)
+def get_places(city_id):
+    """Retrieves the list of all Place objects of a City"""
+    city = storage.get(City, city_id)
+    if city is None:
+        abort(404)
+    places_list = []
+    for place in city.places:
+        places_list.append(place.to_dict())
+    return jsonify(places_list)
+
+
+@app_views.route('/places/<string:place_id>', methods=['GET'],
+                 strict_slashes=False)
+def get_place(place_id):
+    """Retrieves a Place object"""
+    place = storage.get(Place, place_id)
+    if place is None:
+        abort(404)
+    return jsonify(place.to_dict())
+
+
+@app_views.route('/places/<string:place_id>', methods=['DELETE'],
+                 strict_slashes=False)
+def delete_place(place_id):
+    """Deletes a Place object"""
+    place = storage.get(Place, place_id)
+    if place is None:
+        abort(404)
+    storage.delete(place)
+    storage.save()
+    return {}, 200
+
+
+@app_views.route('/cities/<string:city_id>/places', methods=['POST'],
+                 strict_slashes=False)
+def create_place(city_id):
+    """Creates a Place"""
+    city = storage.get(City, city_id)
+    if city is None:
+        abort(404)
+    place_dict = request.get_json()
+    if place_dict is None:
+        abort(400, 'Not a JSON')
+    if 'user_id' not in place_dict.keys():
+        abort(400, 'Missing user_id')
+    if 'name' not in place_dict.keys():
+        abort(400, 'Missing name')
+    user = storage.get(User, place_dict['user_id'])
+    if user is None:
+        abort(404)
+    place_dict['city_id'] = city_id
+    new_place = Place(**place_dict)
+    storage.new(new_place)
+    storage.save()
+    return jsonify(new_place.to_dict()), 201
+
+
+@app_views.route('/places/<string:place_id>', methods=['PUT'],
+                 strict_slashes=False)
+def update_place(place_id):
+    """Updates a Place object"""
+    place = storage.get(Place, place_id)
+    if place is None:
+        abort(404)
+    place_dict = request.get_json()
+    if place_dict is None:
+        abort(400, 'Not a JSON')
+    for key, value in place_dict.items():
+        if key not in ['id', 'user_id', 'city_id', 'created_at',
+                       'updated_at']:
+            setattr(place, key, value)
+    storage.save()
+    return jsonify(place.to_dict())

--- a/api/v1/views/places_reviews.py
+++ b/api/v1/views/places_reviews.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+"""Place review objects that handles all default RestFul API actions"""
+
+from flask import jsonify, abort, request
+from models import storage
+from api.v1.views import app_views
+from models.place import Place
+from models.review import Review
+
+
+@app_views.route('/places/<string:place_id>/reviews', methods=['GET'],
+                 strict_slashes=False)
+def get_reviews(place_id):
+    """Retrieves the list of all Review objects of a Place"""
+    place = storage.get(Place, place_id)
+    if place is None:
+        abort(404)
+    reviews_list = []
+    for review in place.reviews:
+        reviews_list.append(review.to_dict())
+    return jsonify(reviews_list)
+
+
+@app_views.route('/reviews/<string:review_id>', methods=['GET'],
+                 strict_slashes=False)
+def get_review(review_id):
+    """Retrieves a Review object"""
+    review = storage.get(Review, review_id)
+    if review is None:
+        abort(404)
+    return jsonify(review.to_dict())
+
+
+@app_views.route('/reviews/<string:review_id>', methods=['DELETE'],
+                 strict_slashes=False)
+def delete_review(review_id):
+    """Deletes a Review object"""
+    review = storage.get(Review, review_id)
+    if review is None:
+        abort(404)
+    storage.delete(review)
+    storage.save()
+    return {}, 200
+
+
+@app_views.route('/places/<string:place_id>/reviews', methods=['POST'],
+                 strict_slashes=False)
+def create_review(place_id):
+    """Creates a Review"""
+    place = storage.get(Place, place_id)
+    if place is None:
+        abort(404)
+    review_dict = request.get_json()
+    if review_dict is None:
+        abort(400, 'Not a JSON')
+    if 'user_id' not in review_dict.keys():
+        abort(400, 'Missing user_id')
+    if 'text' not in review_dict.keys():
+        abort(400, 'Missing text')
+    review_dict['place_id'] = place_id
+    new_review = Review(**review_dict)
+    storage.new(new_review)
+    storage.save()
+    return jsonify(new_review.to_dict()), 201
+
+
+@app_views.route('/reviews/<string:review_id>', methods=['PUT'],
+                 strict_slashes=False)
+def update_review(review_id):
+    """Updates a Review object"""
+    review = storage.get(Review, review_id)
+    if review is None:
+        abort(404)
+    review_dict = request.get_json()
+    if review_dict is None:
+        abort(400, 'Not a JSON')
+    for key, value in review_dict.items():
+        if key not in ['id', 'user_id', 'place_id', 'created_at',
+                       'updated_at']:
+            setattr(review, key, value)
+    storage.save()
+    return jsonify(review.to_dict())
+
+
+if __name__ == '__main__':
+    pass

--- a/api/v1/views/users.py
+++ b/api/v1/views/users.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python3
+"""Users objects that handles all default RestFul API actions"""
+
+from flask import jsonify, abort, request
+from models import storage
+from api.v1.views import app_views
+from models.user import User
+
+
+@app_views.route('/users', methods=['GET'], strict_slashes=False)
+def get_users():
+    """Retrieves the list of all User objects"""
+    users_list = []
+    for user in storage.all(User).values():
+        users_list.append(user.to_dict())
+    return jsonify(users_list)
+
+
+@app_views.route('/users/<string:user_id>', methods=['GET'],
+                 strict_slashes=False)
+def get_user(user_id):
+    """Retrieves a User object"""
+    user = storage.get(User, user_id)
+    if user is None:
+        abort(404)
+    return jsonify(user.to_dict())
+
+
+@app_views.route('/users/<string:user_id>', methods=['DELETE'],
+                 strict_slashes=False)
+def delete_user(user_id):
+    """Deletes a User object"""
+    user = storage.get(User, user_id)
+    if user is None:
+        abort(404)
+    storage.delete(user)
+    storage.save()
+    return {}, 200
+
+
+@app_views.route('/users', methods=['POST'], strict_slashes=False)
+def create_user():
+    """Creates a User"""
+    user_dict = request.get_json()
+    if user_dict is None:
+        abort(400, 'Not a JSON')
+    if 'email' not in user_dict.keys():
+        abort(400, 'Missing email')
+    if 'password' not in user_dict.keys():
+        abort(400, 'Missing password')
+    new_user = User(**user_dict)
+    storage.new(new_user)
+    storage.save()
+    return jsonify(new_user.to_dict()), 201
+
+
+@app_views.route('/users/<string:user_id>', methods=['PUT'],
+                 strict_slashes=False)
+def update_user(user_id):
+    """Updates a User object"""
+    user = storage.get(User, user_id)
+    if user is None:
+        abort(404)
+    user_dict = request.get_json()
+    if user_dict is None:
+        abort(400, 'Not a JSON')
+    for key, value in user_dict.items():
+        if key not in ['id', 'email', 'created_at', 'updated_at']:
+            setattr(user, key, value)
+    storage.save()
+    return jsonify(user.to_dict()), 200
+
+
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
The code changes introduce new API endpoints for managing users. This includes retrieving a list of users, retrieving a specific user, deleting a user, creating a new user, and updating an existing user. The endpoints are implemented in the `users.py` module under the `api/v1/views` directory.

The commit message follows the established convention of starting with a type prefix (`feat` for feature) and provides a concise summary of the changes made.